### PR TITLE
Fix build for some systems

### DIFF
--- a/src/gui_qt.cpp
+++ b/src/gui_qt.cpp
@@ -1803,7 +1803,7 @@ gui_mch_register_sign(char_u *signfile)
 
 void * qt_socket_notifier_read(int fd, void (fptr)(int))
 {
-	auto in = new QSocketNotifier(fd, QSocketNotifier::Read);
+	QSocketNotifier *in = new QSocketNotifier(fd, QSocketNotifier::Read);
 	QObject::connect(in, &QSocketNotifier::activated, [fd, fptr]() {
 			fptr(fd);
 		});
@@ -1812,7 +1812,7 @@ void * qt_socket_notifier_read(int fd, void (fptr)(int))
 
 void * qt_socket_notifier_ex(int fd, void (fptr)(int))
 {
-	auto err = new QSocketNotifier(fd, QSocketNotifier::Exception);
+	QSocketNotifier *err = new QSocketNotifier(fd, QSocketNotifier::Exception);
 	QObject::connect(err, &QSocketNotifier::activated, [fd, fptr]() {
 			fptr(fd);
 		});
@@ -1824,7 +1824,7 @@ void qt_remove_socket_notifier(void *inp)
 	if (inp == NULL) {
 		return;
 	}
-	auto n = (QSocketNotifier *) inp;
+	QSocketNotifier *n = (QSocketNotifier *) inp;
 	n->setEnabled(false);
 	n->deleteLater();
 }


### PR DESCRIPTION
ref  #13 - it seems my previous changes break the build in some systems.

The **auto** keyword is easier to avoid, the harder part is to replace the lambdas https://bugreports.qt.io/browse/QTBUG-27813