### PR TITLE
Build gui_qt.cpp with -std=c++11

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3109,7 +3109,7 @@ objects/gui_athena.o: gui_athena.c
 
 ## Qt objects
 objects/gui_qt.o: gui_qt.cpp
-	$(CXX) $(ALL_CFLAGS) -o $@ -c gui_qt.cpp
+	$(CXX) $(ALL_CFLAGS) -std=c++11 -o $@ -c gui_qt.cpp
 
 objects/mainwindow.o: qt/mainwindow.cpp
 	$(MOC) qt/mainwindow.h > mainwindow.moc


### PR DESCRIPTION
The lambdas and templates in gui_qt.cpp require C++11.

Remove #15 if this works.

@osa1 does this work for #13. I got it to work in a fresh install of 16.04, but the compiler is 5.3 instead of 5.4